### PR TITLE
[FIX] Bugs in update rule and bug from side-effect due to callable `T`

### DIFF
--- a/sirfshampoo/optimizer.py
+++ b/sirfshampoo/optimizer.py
@@ -446,7 +446,7 @@ class SIRFShampoo(Optimizer):
         # 2) UPDATE THE KRONECKER FACTORS
         # NOTE `GK`, `KT_K`, and `Tr_KTK` have scalings to improve numerical stability.
         # Therefore, the update reads differently to the version in the paper.
-        for n, dt, dim, m_K, K in zip(range(N), dtypes, dims, m_Ks, Ks):
+        for n, dt, m_K, K in zip(range(N), dtypes, m_Ks, Ks):
             not_n = list(range(n)) + list(range(n + 1, N))
             GK = GK.to(dt)
             m_K_step = K.from_dense(


### PR DESCRIPTION
Some bugs were simply using a wrong matrix or flag inside the update rule.

The other bug was more subtle and was caused when using a `class` to specify the update frequency.
The class had an internal state, and during overwriting the parameter groups, the same class would be used by multiple groups. This then led to a side-effect that updating one group bumped an internal counter and prevented the other groups from updating.

With this version, `SIRFShampoo` achieves the same accuracy than the prototype implementation when using `float32` as preconditioner data type on GCViT+ImageWoof (after one epoch).