### PR TITLE
[ADD] @yorkerlin's scaling trick during pre-conditioning, re-order operations [no ci]

### DIFF
--- a/sirfshampoo/optimizer.py
+++ b/sirfshampoo/optimizer.py
@@ -449,11 +449,10 @@ class SIRFShampoo(Optimizer):
         for n, dt, m_K, K in zip(range(N), dtypes, m_Ks, Ks):
             not_n = list(range(n)) + list(range(n + 1, N))
             GK = GK.to(dt)
-            m_K_step = K.from_dense(
-                tensordot(GK, GK, dims=(not_n, not_n)).mul_(dims[n] / 2)
+            m_K_step = KTKs.pop(0).mul_(lam / 2 * Tr_KTKs[not_n].prod() * dims.prod())
+            m_K_step.add_(
+                K.from_dense(tensordot(GK, GK, dims=(not_n, not_n))), alpha=dims[n] / 2
             )
-            KTK_n = KTKs.pop(0)
-            m_K_step.add_(KTK_n, alpha=lam / 2 * Tr_KTKs[not_n].prod() * dims.prod())
             m_K_step.diag_add_(-gamma / 2)
 
             # Update Riemannian momentum on K_n


### PR DESCRIPTION
This PR re-orders the operations from the Riemannian momentum update to make them the same as in the prototype implementation. It also introduces a scaling trick that is used in the prototype during pre-conditioning.