### PR TITLE
[OPT] Efficiently extract structured matrix from gradient outer product

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ setup_requires =
   setuptools_scm
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
-    singd>=0.0.3
+    singd>=0.0.4
     torch
     numpy
 # The usage of test_requires is discouraged, see `Dependency Management` docs


### PR DESCRIPTION
Resolves #24.

This avoids building up a dense for the gradient outer product of an axis if we use structured Kronecker factors.
This significantly reduces memory consumption, e.g. when using a diagonal pre-conditioner for parameters of embedding layers.