### PR TITLE
[ADD] Expose functionality to define customized pre-conditioner groups

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,4 +4,11 @@
             - __init__
             - step
             - state_dict
-            - load_dict
+            - load_state_dict
+
+::: sirfshampoo.PreconditionerGroup
+
+::: sirfshampoo.PerParameter
+    options:
+        members:
+            - __init__

--- a/sirfshampoo/__init__.py
+++ b/sirfshampoo/__init__.py
@@ -1,7 +1,10 @@
 """sirfshampoo library."""
 
+from sirfshampoo.combiner import PerParameter, PreconditionerGroup
 from sirfshampoo.optimizer import SIRFShampoo
 
 __all__ = [
     "SIRFShampoo",
+    "PreconditionerGroup",
+    "PerParameter",
 ]

--- a/sirfshampoo/combiner.py
+++ b/sirfshampoo/combiner.py
@@ -7,15 +7,20 @@ from torch import Size, Tensor
 from torch.nn import Module, Parameter
 
 
-class TensorGroup(ABC):
-    """Interface for treating multiple tensors with one pre-conditioner."""
+class PreconditionerGroup(ABC):
+    """Interface for treating multiple tensors with one pre-conditioner.
+
+    Users who want to specify their own rule how to group parameters into a tensor
+    which is then treated with a Kronecker-factored pre-conditioner should implement
+    this interface.
+    """
 
     @abstractmethod
     def identify(self, model: Module) -> List[List[Parameter]]:
         """Detect parameters that should be treated jointly.
 
         Args:
-            Module: The neural network.
+            model: The neural network.
 
         Returns:
             A list whose entries are list of parameters that are treated jointly.
@@ -63,14 +68,14 @@ class TensorGroup(ABC):
         raise NotImplementedError
 
 
-class PerParameter(TensorGroup):
-    """Treat each parameter with a separate pre-conditioner."""
+class PerParameter(PreconditionerGroup):
+    """Pre-conditioner group to treat each parameter with its own pre-conditioner."""
 
     def identify(self, model: Module) -> List[List[Parameter]]:
         """Detect parameters that should be treated jointly.
 
         Args:
-            Module: The neural network.
+            model: The neural network.
 
         Returns:
             A list of lists. Each sub-list contains one parameter.
@@ -110,7 +115,7 @@ class PerParameter(TensorGroup):
         return [grouped_tensor.reshape(shape)]
 
 
-# class LinearWeightAndBias(TensorGroup):
+# class LinearWeightAndBias(PreconditionerGroup):
 #     """Treat weight and bias of a linear layer jointly.
 
 #     Stacks the bias as last column to the weight matrix.

--- a/sirfshampoo/combiner.py
+++ b/sirfshampoo/combiner.py
@@ -1,15 +1,32 @@
 """Abstraction for combining multiple tensors into one."""
 
+from abc import ABC, abstractmethod
 from typing import List
 
-from torch import Size, Tensor, cat, split, stack
+from torch import Size, Tensor
+from torch.nn import Module, Parameter
 
 
-class TensorCombiner:
-    """Class for combining multiple tensors into one."""
+class TensorGroup(ABC):
+    """Interface for treating multiple tensors with one pre-conditioner."""
 
-    @staticmethod
-    def group(tensors: List[Tensor]) -> Tensor:
+    @abstractmethod
+    def identify(self, model: Module) -> List[List[Parameter]]:
+        """Detect parameters that should be treated jointly.
+
+        Args:
+            Module: The neural network.
+
+        Returns:
+            A list whose entries are list of parameters that are treated jointly.
+
+        Raises:
+            NotImplementedError: Must be implemented by a child class.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def group(self, tensors: List[Tensor]) -> Tensor:
         """Combine multiple tensors into one.
 
         This is the inverse operation of `ungroup`.
@@ -21,38 +38,14 @@ class TensorCombiner:
             Combined tensor.
 
         Raises:
-            NotImplementedError: If the supplied tensor shapes cannot be combined.
+            NotImplementedError: Must be implemented by a child class.
         """
-        # one tensor only
-        if len(tensors) == 1:
-            # squeeze dimensions of size 1, treat scalars as vectors
-            squeezed = tensors[0].squeeze()
-            return squeezed.unsqueeze(0) if squeezed.ndim == 0 else squeezed
+        raise NotImplementedError
 
-        # combining a weight and bias
-        if len(tensors) == 2:
-            # TODO Could allow general order here
-            W, b = tensors
-
-            # linear layer
-            if W.ndim == 2 and b.ndim == 1 and W.shape[0] == b.shape[0]:
-                return cat([W, b.unsqueeze(1)], dim=1)
-
-            # 2d convolutional layer
-            if W.ndim == 4 and b.ndim == 1 and W.shape[0] == b.shape[0]:
-                return cat([W.flatten(start_dim=1), b.unsqueeze(1)], dim=1)
-
-        # all tensors have the same shape (e.g. weight and bias of a normalization
-        # layer): stack them along a new trailing dimension
-        if len({tensor.shape for tensor in tensors}) == 1:
-            return stack(tensors, dim=tensors[0].ndim)
-
-        raise NotImplementedError(
-            f"Cannot combine tensors of shape {[t.shape for t in tensors]}."
-        )
-
-    @staticmethod
-    def ungroup(grouped_tensor: Tensor, tensor_shapes: List[Size]) -> List[Tensor]:
+    @abstractmethod
+    def ungroup(
+        self, grouped_tensor: Tensor, tensor_shapes: List[Size]
+    ) -> List[Tensor]:
         """Split a combined tensor into multiple tensors.
 
         This is the inverse operation of `group`.
@@ -65,39 +58,86 @@ class TensorCombiner:
             List of tensors.
 
         Raises:
-            NotImplementedError: If the supplied tensor shapes cannot be split.
+            NotImplementedError: Must be implemented by a child class.
         """
-        # one tensor only
-        if len(tensor_shapes) == 1:
-            return [grouped_tensor.reshape(tensor_shapes[0])]
+        raise NotImplementedError
 
-        # combining a weight and bias
-        if len(tensor_shapes) == 2:
-            # TODO Could allow general order here
-            W_shape, b_shape = tensor_shapes
 
-            # linear layer
-            if len(W_shape) == 2 and len(b_shape) == 1 and W_shape[0] == b_shape[0]:
-                W, b = split(grouped_tensor, [W_shape[1], 1], dim=1)
-                return [W, b.squeeze(1)]
+class PerParameter(TensorGroup):
+    """Treat each parameter with a separate pre-conditioner."""
 
-            # 2d convolutional layer
-            if len(W_shape) == 4 and len(b_shape) == 1 and W_shape[0] == b_shape[0]:
-                W, b = split(grouped_tensor, [W_shape[1:].numel(), 1], dim=1)
-                return [W.reshape(W_shape), b.squeeze(1)]
+    def identify(self, model: Module) -> List[List[Parameter]]:
+        """Detect parameters that should be treated jointly.
 
-        # all tensors have the same shape (e.g. weight and bias of a normalization
-        # layer): split them along the trailing dimension
-        if (
-            len(set(tensor_shapes)) == 1
-            and grouped_tensor.shape[:-1] == tensor_shapes[0]
-        ):
-            return [
-                t.squeeze(-1)
-                for t in split(grouped_tensor, 1, dim=grouped_tensor.ndim - 1)
-            ]
+        Args:
+            Module: The neural network.
 
-        raise NotImplementedError(
-            f"Cannot ungroup tensor of shape {grouped_tensor.shape} into tensors of"
-            + f" shape {tensor_shapes}."
-        )
+        Returns:
+            A list of lists. Each sub-list contains one parameter.
+        """
+        return [[p] for p in model.parameters()]
+
+    def group(self, tensors: List[Tensor]) -> Tensor:
+        """Combine tensors that are pre-conditioned jointly.
+
+        Args:
+            tensors: List of tensors to combine.
+
+        Returns:
+            Combined tensor. Axes of size 1 are squeezed to avoid an unnecessary 1x1
+            Kronecker factor in the pre-conditioner.
+        """
+        (tensor,) = tensors
+        squeezed = tensor.squeeze()
+        return squeezed.unsqueeze(0) if squeezed.ndim == 0 else squeezed
+
+    def ungroup(
+        self, grouped_tensor: Tensor, tensor_shapes: List[Size]
+    ) -> List[Tensor]:
+        """Split a combined tensor into multiple tensors.
+
+        This is the inverse operation of `group`.
+
+        Args:
+            grouped_tensor: Combined tensor.
+            tensor_shapes: Shapes of the tensors to split into.
+
+        Returns:
+            List of tensors of length 1. Entry tensor has the same shape as the
+            parameter.
+        """
+        (shape,) = tensor_shapes
+        return [grouped_tensor.reshape(shape)]
+
+
+# class LinearWeightAndBias(TensorGroup):
+#     """Treat weight and bias of a linear layer jointly.
+
+#     Stacks the bias as last column to the weight matrix.
+#     """
+
+#     def identify(self, model: Module) -> List[List[Parameter]]:
+#         return [
+#             [module.weight, module.bias]
+#             for module in model.modules()
+#             if isinstance(module, Linear) and module.bias is not None
+#         ]
+
+#     def group(self, tensors: List[Tensor]) -> Tensor:
+#         t_weight, t_bias = tensors
+#         combined = stack([t_weight, t_bias.unsqueeze(1)], dim=1).squeeze()
+#         return combined.unsqueeze(0) if combined.ndim == 0 else combined
+
+#     def ungroup(
+#         self, grouped_tensor: Tensor, tensor_shapes: List[Size]
+#     ) -> List[Tensor]:
+#         (shape_weight, shape_bias) = tensor_shapes
+
+#         # if the `Linear` layer has `out_features=1`, then one dimension of the
+#         # weight matrix will be squeezed during the call to `group`.
+#         split_dim = 0 if grouped_tensor.ndim == 1 else 1
+
+#         d_in = shape_weight[1]
+#         t_weight, t_bias = split(grouped_tensor, [d_in, 1], dim=split_dim)
+
+#         return [t_weight.reshape(shape_weight), t_bias.reshape(shape_bias)]

--- a/sirfshampoo/optimizer.py
+++ b/sirfshampoo/optimizer.py
@@ -16,7 +16,7 @@ from torch import Tensor, dtype, zeros_like
 from torch.nn import Module, Parameter
 from torch.optim import Optimizer
 
-from sirfshampoo.combiner import TensorCombiner
+from sirfshampoo.combiner import PerParameter, TensorGroup
 from sirfshampoo.utils import tensormatdot
 
 
@@ -72,6 +72,7 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
         preconditioner_dtypes: Optional[
             Union[dtype, Dict[int, Union[None, dtype, Tuple[Union[None, dtype], ...]]]]
         ] = None,
+        combine_params: Tuple[TensorGroup] = (PerParameter(),),
         verbose_init: bool = False,
     ):
         """Set up the optimizer.
@@ -144,6 +145,7 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
             T=T,
             structures=structures,
             preconditioner_dtypes=preconditioner_dtypes,
+            combine_params=combine_params,
         )
 
         if params is None:
@@ -184,7 +186,7 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
         # parameter group contains the parameters that are treated jointly with one
         # pre-conditioner. This simplifies book-keeping when updating the
         # pre-conditioner and taking a step.
-        self._one_param_group_per_preconditioner()
+        self._one_param_group_per_preconditioner(model)
         # convert structure and dtype arguments into tuples
         self._standardize_structures()
         self._standardize_preconditioner_dtypes()
@@ -241,13 +243,9 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
                 f"\n\t- Pre-conditioner: {prec_desc}\n\t- Other: {other}"
             )
 
-    def _one_param_group_per_preconditioner(self) -> None:
+    def _one_param_group_per_preconditioner(self, model: Module) -> None:
         """Overwrite param groups so that one group shares a pre-conditioner."""
         params = sum((group["params"] for group in self.param_groups), [])
-
-        # create list entries where each entry lists parameters that are treated jointly
-        # treat each parameter with an independent pre-conditioner
-        treat_jointly = [[p] for p in params]
 
         # create new parameter groups, one per pre-conditioner
         param_to_group = {
@@ -255,17 +253,46 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
             for i, group in enumerate(self.param_groups)
             for p in group["params"]
         }
+
+        treat_jointly = []
+        combiners = []
+
+        # figure out which parameters to treat jointly with one pre-conditioner
+        for i, group in enumerate(self.param_groups):
+            for combiner in group["combine_params"]:
+                candidates = combiner.identify(model)
+                for candidate in candidates:
+                    processed = [p.data_ptr() for p in sum(treat_jointly, [])]
+                    if all(
+                        p.requires_grad
+                        and p.data_ptr() not in processed
+                        and p.data_ptr() in param_to_group
+                        and param_to_group[p.data_ptr()] == i
+                        for p in candidate
+                    ):
+                        treat_jointly.append(candidate)
+                        combiners.append(combiner)
+
         new_param_groups = []
-        for params in treat_jointly:
+        for params, combiner in zip(treat_jointly, combiners):
             old_group = self.param_groups[param_to_group[params[0].data_ptr()]]
 
             # If T is a class with internal state we do not want this state to be shared
             # between parameter groups because otherwise calling T of one parameter
             # group might have side effects on other groups that use the same T.
             # Hence, create an independent copy if T is callable.
+            # Same for the class handling (un-)grouping the tensors
             T = deepcopy(old_group["T"]) if callable(old_group["T"]) else old_group["T"]
+            combine_params = deepcopy(combiner)
 
-            new_param_groups.append({**old_group, "params": params, "T": T})
+            new_param_groups.append(
+                {
+                    **old_group,
+                    "params": params,
+                    "T": T,
+                    "combine_params": combine_params,
+                }
+            )
 
         self.param_groups = new_param_groups
 
@@ -312,7 +339,8 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
 
         for group in self.param_groups:
             params = group["params"]
-            N = TensorCombiner().group(params).ndim
+            combiner = group["combine_params"]
+            N = combiner.group(params).ndim
 
             structures = group["structures"]
             if len(structures) != N:
@@ -365,7 +393,8 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
             dtypes = group["preconditioner_dtypes"]
             kwargs = [{"dtype": dt, "device": dev} for dt in dtypes]
 
-            dims = TensorCombiner.group(params).shape
+            combiner = group["combine_params"]
+            dims = combiner.group(params).shape
 
             if not len(dtypes) == len(classes) == len(dims):
                 raise RuntimeError(
@@ -444,9 +473,10 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
         alpha2 = group["alpha2"]
         beta2 = group["beta2"]
         lam = group["lam"]
+        combiner = group["combine_params"]
 
         # arrange the gradients into the tensor that is pre-conditioned
-        G = TensorCombiner.group([p.grad for p in group["params"]])
+        G = combiner.group([p.grad for p in group["params"]])
         dims = G.shape
         dtypes = group["preconditioner_dtypes"]
 
@@ -512,7 +542,8 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
         """
         group = self.param_groups[group_idx]
         params = group["params"]
-        G = TensorCombiner.group([p.grad for p in params])
+        combiner = group["combine_params"]
+        G = combiner.group([p.grad for p in params])
         dtypes = group["preconditioner_dtypes"]
         Ks = self.preconditioner[group_idx]
         (N,) = {len(Ks), len(dtypes), G.ndim}
@@ -533,7 +564,7 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
         # correct the scaling
         G.mul_((scales**2).prod())
 
-        return TensorCombiner.ungroup(G, [p.shape for p in params])
+        return combiner.ungroup(G, [p.shape for p in params])
 
     def _standardize_structures(self):
         """Standardize the values for structures in parameter groups.
@@ -547,9 +578,10 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
         for group in self.param_groups:
             structures = group["structures"]
             params = group["params"]
+            combiner = group["combine_params"]
 
             # number of Kronecker factors
-            N = TensorCombiner.group(params).ndim
+            N = combiner.group(params).ndim
 
             # overwrite structures in parameter group
             if isinstance(structures, str):
@@ -583,9 +615,10 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
         for group in self.param_groups:
             dtypes = group["preconditioner_dtypes"]
             params = group["params"]
+            combiner = group["combine_params"]
 
             # number of Kronecker factors
-            N = TensorCombiner.group(params).ndim
+            N = combiner.group(params).ndim
 
             # detect data types and overwrite entry in parameter groups
             if isinstance(dtypes, dtype) or dtypes is None:

--- a/test/test_combiner.py
+++ b/test/test_combiner.py
@@ -1,196 +1,59 @@
 """Test combining and splitting tensors."""
 
 from test.utils import DEVICE_IDS, DEVICES
-from typing import List, Tuple
 
-from pytest import mark, raises
-from torch import Size, allclose, device, manual_seed, rand
+from pytest import mark
+from torch import allclose, device, manual_seed, rand
+from torch.nn import Linear
 
-from sirfshampoo.combiner import TensorCombiner
-
-GROUPING_SHAPES = [
-    [(2,)],  # one 1d tensor
-    [(2, 1)],  # 2d tensor with trivial axis
-    [(2, 3, 4)],  # one tensor only
-    [(2, 3, 4), (2, 3, 4), (2, 3, 4)],  # multiple tensors of same shape
-    [(4, 3), (4,)],  # weight and bias of a linear layer
-    [(4, 3, 2, 2), (4,)],  # weight and bias of a 2d convolutional layer
-]
-
-
-UNSUPPORTED_GROUPING_SHAPES = [
-    [(2, 3, 4), (5,)],  # no obvious strategy
-    # NOTE We could support arbitrary order of bias and weight
-    [(4,), (4, 3)],  # bias and weight of a linear layer
-    [(4,), (4, 3, 2, 2)],  # bias and weight of a 2d convolutional layer
-]
-
-
-def _check_group_then_ungroup(shapes: List[Tuple[int, ...]], dev: device):
-    """Generate random tensors and try to group and ungroup them.
-
-    Verify that `ungroup(group) = identity`.
-
-    Args:
-        shapes: Shapes of the tensors to generate.
-        dev: The device to run the test on.
-    """
-    tensors = [rand(shape, device=dev) for shape in shapes]
-    grouped = TensorCombiner.group(tensors)
-    # TODO We could relax this condition in cases where one wants to
-    # pad smaller tensors so they can be stacked with other tensors,
-    # which would increase the number of elements in the grouped tensor.
-    assert grouped.numel() == sum(t.numel() for t in tensors)
-    # `ungroup` requires the shapes to be of type `Size`
-    tensor_shapes = [Size(shape) for shape in shapes]
-    ungrouped = TensorCombiner.ungroup(grouped, tensor_shapes)
-    assert len(tensors) == len(ungrouped)
-    assert all(allclose(t1, t2) for t1, t2 in zip(tensors, ungrouped))
+from sirfshampoo.combiner import PerParameter
 
 
 @mark.parametrize("dev", DEVICES, ids=DEVICE_IDS)
-@mark.parametrize("shapes", GROUPING_SHAPES, ids=str)
-def test_TensorCombiner_group_then_ungroup(shapes: List[Tuple[int, ...]], dev: device):
-    """Test `group` and `ungroup` methods of `TensorCombiner`.
+def test_PerParameter_identify(dev: device):
+    """Test parameter identification of `PerParameter` class.
 
     Args:
-        shapes: Shapes of the tensors to generate and combine.
-        dev: The device to run the test on.
+        dev: Device to run the test on.
     """
-    manual_seed(0)
-    _check_group_then_ungroup(shapes, dev)
+    model = Linear(2, 3).to(dev)
+    assert PerParameter().identify(model) == [[model.weight], [model.bias]]
 
 
 @mark.parametrize("dev", DEVICES, ids=DEVICE_IDS)
-@mark.parametrize("shapes", UNSUPPORTED_GROUPING_SHAPES, ids=str)
-def test_TensorCombiner_unsupported_group_then_ungroup(
-    shapes: List[Tuple[int, ...]], dev: device
-):
-    """Test unsupported cases of `group` and `ungroup`.
-
-    Args:
-        shapes: Shapes of the tensors to generate and combine.
-        dev: The device to run the test on.
-    """
-    manual_seed(0)
-    with raises(NotImplementedError):
-        _check_group_then_ungroup(shapes, dev)
-
-
-# first entry is shape of grouped tensor, second entry is list of shapes of ungrouped
-# tensors
-UNGROUPING_CASES = [
-    # one tensor only
-    (
-        (2, 3, 4),
-        [(2, 3, 4)],
-    ),
-    # multiple tensors of same shape
-    (
-        (2, 3, 4, 3),
-        [(2, 3, 4), (2, 3, 4), (2, 3, 4)],
-    ),
-    # weight and bias of a linear layer
-    (
-        (4, 4),
-        [(4, 3), (4,)],
-    ),
-    # weight and bias of a 2d convolutional layer
-    (
-        (4, 13),
-        [(4, 3, 2, 2), (4,)],
-    ),
-]
-
-UNSUPPORTED_UNGROUPING_CASES = [
-    # no obvious strategy
-    [
-        (120,),
-        [(2, 3, 4), (5,)],
-    ],
-    # NOTE We could support arbitrary order of bias and weight
-    # bias and weight of a linear layer
-    [
-        (4, 4),
-        [(4,), (4, 3)],
-    ],
-    # bias and weight of a 2d convolutional layer
-    [
-        (4, 13),
-        [(4,), (4, 3, 2, 2)],
-    ],
-]
-
-
-@mark.parametrize("dev", DEVICES, ids=DEVICE_IDS)
-def _check_ungroup_then_group(
-    grouped_shape: Tuple[int, ...], ungrouped_shapes: List[Tuple[int, ...]], dev: device
-):
-    """Generate a random tensor and try to ungroup group it.
-
-    Verify that `group(ungroup) = identity`.
-
-    Args:
-        grouped_shape: Shape of the grouped tensor.
-        ungrouped_shapes: Shapes of the tensors to ungroup.
-        dev: The device to run the test on.
-    """
-    # `ungroup` requires the shapes to be of type `Size`
-    ungrouped_shapes = [Size(shape) for shape in ungrouped_shapes]
-    tensor = rand(grouped_shape, device=dev)
-    ungrouped = TensorCombiner.ungroup(tensor, ungrouped_shapes)
-    assert len(ungrouped) == len(ungrouped_shapes)
-    assert all(t.shape == s for t, s in zip(ungrouped, ungrouped_shapes))
-    # TODO We could relax this condition in cases where one wants to
-    # pad smaller tensors so they can be stacked with other tensors,
-    # which would increase the number of elements in the grouped tensor.
-    assert tensor.numel() == sum(t.numel() for t in ungrouped)
-    grouped = TensorCombiner.group(ungrouped)
-    assert allclose(tensor, grouped)
-
-
-@mark.parametrize("dev", DEVICES, ids=DEVICE_IDS)
-@mark.parametrize("case", UNGROUPING_CASES, ids=str)
-def test_TensorCombiner_ungroup_then_group(
-    case: Tuple[Tuple[int, ...], List[Tuple[int, ...]]], dev: device
-):
-    """Test `ungroup` and `group` methods of `TensorCombiner`.
-
-    Args:
-        case: Shape of the grouped tensor and shapes of the ungrouped tensors.
-        dev: The device to run the test on.
-    """
-    manual_seed(0)
-    _check_ungroup_then_group(*case, dev)
-
-
-@mark.parametrize("dev", DEVICES, ids=DEVICE_IDS)
-@mark.parametrize("case", UNSUPPORTED_UNGROUPING_CASES, ids=str)
-def test_TensorCombiner_unsupported_ungroup_then_group(
-    case: Tuple[Tuple[int, ...], List[Tuple[int, ...]]], dev: device
-):
-    """Test unsupported cases of `ungroup` and `group`.
-
-    Args:
-        case: Shape of the grouped tensor and shapes of the ungrouped tensors.
-        dev: The device to run the test on.
-    """
-    manual_seed(0)
-    with raises(NotImplementedError):
-        _check_ungroup_then_group(*case, dev)
-
-
-@mark.parametrize("dev", DEVICES, ids=DEVICE_IDS)
-def test_TensorCombiner_group_trivial_axes(dev: device):
-    """Test combiner when it encounters tensors with dimensions of size 1.
+def test_PerParameter_group_and_ungroup(dev: device):
+    """Test tensor (un-)grouping of `PerParameter` class.
 
     Args:
         dev: Device to run the test on.
     """
     manual_seed(0)
-    t = rand(2, 1, 3, 1, device=dev)
-    assert TensorCombiner().group([t]).shape == (2, 3)
 
-    t = rand(1, device=dev).squeeze()
-    assert t.ndim == 0
-    assert TensorCombiner().group([t]).shape == (1,)
+    # regular shape
+    tensor = rand(5, 10, 7, device=dev)
+    shapes = [tensor.shape]
+
+    grouped = PerParameter().group([tensor])
+    assert allclose(grouped, tensor)
+    (ungrouped,) = PerParameter().ungroup(grouped, shapes)
+    assert allclose(ungrouped, tensor)
+
+    # shape with ones
+    tensor = rand(5, 7, device=dev)
+    tensor_unsqueezed = tensor.unsqueeze(1).unsqueeze(2)
+    shapes = [tensor_unsqueezed.shape]
+
+    grouped = PerParameter().group([tensor_unsqueezed])
+    assert allclose(grouped, tensor)
+    (ungrouped,) = PerParameter().ungroup(grouped, shapes)
+    assert allclose(ungrouped, tensor_unsqueezed)
+
+    # scalar
+    scalar = rand(1, device=dev).squeeze()
+    scalar_unsqueezed = scalar.unsqueeze(0)
+    shapes = [scalar_unsqueezed.shape]
+
+    grouped = PerParameter().group([scalar_unsqueezed])
+    assert allclose(grouped, scalar)
+    (ungrouped,) = PerParameter().ungroup(grouped, shapes)
+    assert allclose(ungrouped, scalar_unsqueezed)


### PR DESCRIPTION
So far, `SIRFShampoo` treats each parameter with an independent pre-conditioner.

This PR introduces a public interface that can be used to combine multiple parameters into a tensor which is then treated with a pre-conditioner. Some example use cases would be:
- Combining the weight matrix and bias vector of a `Linear` layer into one matrix by appending the bias as last column
- Combining the `d`-dimensional weight and bias vectors of a normalization layer into a `dx2` matrix
- Combining multiple (say `L`) weights of shape `d_out x d_in` into a 3d tensor of shape `L x d_out x d_in` (think LLMs)
- Reshaping a parameter tensor with a large dimension into a tensor with higher rank but smaller dimensions per axis (think embedding layers or large last linear layers)