### PR TITLE
[FIX] Synchronize pre-conditioner device when loading from checkpoint

### DIFF
--- a/sirfshampoo/optimizer.py
+++ b/sirfshampoo/optimizer.py
@@ -733,6 +733,7 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
         def to_(K: StructuredMatrix, dev: device) -> StructuredMatrix:
             for name, tensor in K.named_tensors():
                 setattr(K, name, tensor.to(dev))
+            return K
 
         for i, group in enumerate(self.param_groups):
             dev = self._infer_device(group)

--- a/sirfshampoo/optimizer.py
+++ b/sirfshampoo/optimizer.py
@@ -732,7 +732,7 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
 
         def to_(K: StructuredMatrix, dev: device) -> StructuredMatrix:
             for name, tensor in K.named_tensors():
-                setattr(K, name, tensor.do(dev))
+                setattr(K, name, tensor.to(dev))
 
         for i, group in enumerate(self.param_groups):
             dev = self._infer_device(group)

--- a/sirfshampoo/optimizer.py
+++ b/sirfshampoo/optimizer.py
@@ -731,7 +731,7 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
         """
 
         def to_(K: StructuredMatrix, dev: device) -> StructuredMatrix:
-            for name, tensor in K.named_tensors:
+            for name, tensor in K.named_tensors():
                 setattr(K, name, tensor.do(dev))
 
         for i, group in enumerate(self.param_groups):

--- a/sirfshampoo/optimizer.py
+++ b/sirfshampoo/optimizer.py
@@ -11,7 +11,7 @@ from singd.structures.diagonal import DiagonalMatrix
 from singd.structures.hierarchical import Hierarchical15_15Matrix
 from singd.structures.triltoeplitz import TrilToeplitzMatrix
 from singd.structures.triutoeplitz import TriuToeplitzMatrix
-from torch import Tensor, dtype, stack, zeros_like
+from torch import Tensor, device, dtype, stack, zeros_like
 from torch.nn import Module, Parameter
 from torch.optim import Optimizer
 
@@ -413,13 +413,12 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
             classes = [
                 self.SUPPORTED_STRUCTURES[struct] for struct in group["structures"]
             ]
-
-            params = group["params"]
-            (dev,) = {p.device for p in params}
+            dev = self._infer_device(group)
             dtypes = group["preconditioner_dtypes"]
             kwargs = [{"dtype": dt, "device": dev} for dt in dtypes]
 
             combiner = group["combine_params"]
+            params = group["params"]
             dims = combiner.group(params).shape
 
             if not len(dtypes) == len(classes) == len(dims):
@@ -438,11 +437,33 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
                 )
             else:
                 raise ValueError(
-                    f"Unsupported preconditioning method: {method}."
-                    + " Supported methods are 'identity' and 'zero'."
+                    f"Unsupported preconditioning method: {method}. Supported methods are 'identity' and 'zero'."
                 )
 
         return preconditioners
+
+    @staticmethod
+    def _infer_device(group: Dict[str, Any]) -> device:
+        """Infer the device of a parameter group.
+
+        At the moment, all parameters must live on the same device. This defines the
+        group's device.
+
+        Args:
+            group: The parameter group.
+
+        Returns:
+            The device of the group.
+
+        Raises:
+            RuntimeError: If the parameters live on different devices.
+        """
+        devices = {p.device for p in group["params"]}
+        if len(devices) != 1:
+            raise RuntimeError(
+                "Group's parameters live on more than one device: {devices}."
+            )
+        return devices.pop()
 
     def _initialize_momentum_buffers(self):
         """Initialize the momentum buffers."""
@@ -699,3 +720,30 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
 
         for name, value in attributes.items():
             setattr(self, name, value)
+
+        self._sync_preconditioner_device()
+
+    def _sync_preconditioner_device(self):
+        """Synchronize pre-conditioner device with group device.
+
+        The devices can become out-of-sync when loading the optimizer with non-default
+        `map_location` argument in `torch.load`.
+        """
+
+        def to_(K: StructuredMatrix, dev: device) -> StructuredMatrix:
+            for name, tensor in K.named_tensors:
+                setattr(K, name, tensor.do(dev))
+
+        for i, group in enumerate(self.param_groups):
+            dev = self._infer_device(group)
+
+            # synchronize pre-conditioner matrices
+            for n, K_n in enumerate(self.preconditioner[i]):
+                K_n_synced = to_(K_n, dev)
+                self.preconditioner[i][n] = K_n_synced
+
+            # synchronize pre-conditioner momenta
+            for n, m_K_n in enumerate(self.preconditioner_momenta[i]):
+                if m_K_n is not None:
+                    m_K_n_synced = to_(m_K_n, dev)
+                    self.preconditioner_momenta[i][n] = m_K_n_synced

--- a/test/test_checkpointing.py
+++ b/test/test_checkpointing.py
@@ -119,6 +119,5 @@ def test_bug_34_map_location():
     model.load_state_dict(checkpoint["model"])
     optimizer.load_state_dict(checkpoint["optimizer"])
 
-    # this should raise an error
-    with raises(RuntimeError):
-        train()
+    # make sure pre-conditioner device is consistent with gradient/parameters
+    train()

--- a/test/test_checkpointing.py
+++ b/test/test_checkpointing.py
@@ -3,7 +3,7 @@
 from test.utils import compare_optimizers
 from typing import Tuple
 
-from pytest import skip
+from pytest import raises, skip
 from torch import cuda, device, load, manual_seed, rand, save
 from torch.nn import Conv2d, CrossEntropyLoss, Flatten, Linear, Module, ReLU, Sequential
 from torch.utils.data import DataLoader
@@ -120,4 +120,5 @@ def test_bug_34_map_location():
     optimizer.load_state_dict(checkpoint["optimizer"])
 
     # this should raise an error
-    train()
+    with raises(RuntimeError):
+        train()


### PR DESCRIPTION
Fixes #34.

Adds a synchronization step in `load_state_dict` that loads the pre-conditioner and its momentum to the correct device. Otherwise, if the checkpoint was loaded with `map_location='cpu'`, the pre-conditioner matrices live on the incorrect device.

It seems that `Tensor`s that live in the optimizer's `.state` variable, such as Adam's gradient moments, are automatically synced. We cannot use the `.state` variable for two reasons:
1. Keys of `state` are `Parameter`s, but a pre-conditioner belongs to a parameter group, not a parameter.
2. Values of `state` are `Tensor`s, but our pre-conditioner is a list of `StructuredMatrix`s. I am not familiar with the implementation details of syncing the content of `state`, but quite sure our structured matrices will not be recognized and synced.
Therefore, I decided to add an additional syncing step in `load_state_dict`. Let me know if you think there is a better solution.

**NOTE:** Currently only a draft PR, because I think the device transfer of `StructuredMatrix` should be implemented in the SINGD code base.