### PR TITLE
[ADD] Class for treating flattened embedding weights with a pre-conditioner

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Option to treat the flattened embedding weight with one pre-conditioner
+  ([PR](https://github.com/f-dangel/sirfshampoo/pull/36))
+
 ### Changed
 
 ### Deprecated

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,3 +17,8 @@
     options:
         members:
             - __init__
+
+::: sirfshampoo.FlattenEmbedding
+    options:
+        members:
+            - __init__

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ doc =
     mkdocstrings[python]==0.22.0
     mkdocs-gallery==0.7.8
     torchvision # MNIST
+    pytest # for catching exceptions
 
 # Linting
 

--- a/sirfshampoo/__init__.py
+++ b/sirfshampoo/__init__.py
@@ -1,6 +1,11 @@
 """sirfshampoo library."""
 
-from sirfshampoo.combiner import LinearWeightBias, PerParameter, PreconditionerGroup
+from sirfshampoo.combiner import (
+    FlattenEmbedding,
+    LinearWeightBias,
+    PerParameter,
+    PreconditionerGroup,
+)
 from sirfshampoo.optimizer import SIRFShampoo
 
 __all__ = [
@@ -8,4 +13,5 @@ __all__ = [
     "PreconditionerGroup",
     "PerParameter",
     "LinearWeightBias",
+    "FlattenEmbedding",
 ]

--- a/test/test_combiner.py
+++ b/test/test_combiner.py
@@ -4,9 +4,9 @@ from test.utils import DEVICE_IDS, DEVICES
 
 from pytest import mark
 from torch import allclose, device, manual_seed, rand, zeros
-from torch.nn import Linear
+from torch.nn import Embedding, Linear
 
-from sirfshampoo.combiner import LinearWeightBias, PerParameter
+from sirfshampoo.combiner import FlattenEmbedding, LinearWeightBias, PerParameter
 
 
 @mark.parametrize("dev", DEVICES, ids=DEVICE_IDS)
@@ -66,8 +66,9 @@ def test_LinearWeightBias_identify(dev: device):
     Args:
         dev: Device to run the test on.
     """
-    model = Linear(2, 3).to(dev)
-    assert LinearWeightBias().identify(model) == [[model.weight, model.bias]]
+    for linear_cls in LinearWeightBias.LINEAR_CLS:
+        model = linear_cls(2, 3).to(dev)
+        assert LinearWeightBias().identify(model) == [[model.weight, model.bias]]
 
 
 @mark.parametrize("dev", DEVICES, ids=DEVICE_IDS)
@@ -105,3 +106,34 @@ def test_LinearWeightBias_group_and_ungroup(dev: device):
     assert allclose(grouped, tensor)
     (W_ungrouped, b_ungrouped) = LinearWeightBias().ungroup(grouped, shapes)
     assert allclose(W_ungrouped, W) and allclose(b_ungrouped, b)
+
+
+@mark.parametrize("dev", DEVICES, ids=DEVICE_IDS)
+def test_FlattenEmbedding_identify(dev: device):
+    """Test parameter identification of `FlattenEmbedding` class.
+
+    Args:
+        dev: Device to run the test on.
+    """
+    for embedding_cls in FlattenEmbedding.EMBEDDING_CLS:
+        model = embedding_cls(2, 3).to(dev)
+        assert FlattenEmbedding().identify(model) == [[model.weight]]
+
+
+@mark.parametrize("dev", DEVICES, ids=DEVICE_IDS)
+def test_FlattenEmbedding_group_and_ungroup(dev: device):
+    """Test tensor (un-)grouping of `FlattenEmbedding` class.
+
+    Args:
+        dev: Device to run the test on.
+    """
+    manual_seed(0)
+
+    tensor = rand(5, 10, device=dev)
+    tensor_flat = tensor.flatten()
+    shapes = [tensor.shape]
+
+    grouped = FlattenEmbedding().group([tensor])
+    assert allclose(grouped, tensor_flat)
+    (ungrouped,) = FlattenEmbedding().ungroup(grouped, shapes)
+    assert allclose(ungrouped, tensor)

--- a/test/test_combiner.py
+++ b/test/test_combiner.py
@@ -4,7 +4,7 @@ from test.utils import DEVICE_IDS, DEVICES
 
 from pytest import mark
 from torch import allclose, device, manual_seed, rand, zeros
-from torch.nn import Embedding, Linear
+from torch.nn import Linear
 
 from sirfshampoo.combiner import FlattenEmbedding, LinearWeightBias, PerParameter
 


### PR DESCRIPTION
As requested by @yorkerlin, this PR adds the functionality to treat flattened weight matrices of embedding layers.
With this option, we can reshape `W` (2d) into `vec(W)` (1d), and use a pre-conditioner that consists of a single Kronecker factor (usually equipped with diagonal structure). This allows training embedding layer weights with inverse- and root-free RMSProp.