### PR TITLE
[REQ] Bump SINGD, use efficient `.shape` method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,12 +15,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Improve memory efficiency of using `SIRFShampoo` with `verbose_init=True`
-  ([PR](https://github.com/f-dangel/sirfshampoo/pull/37))
-
 ### Deprecated
 
 ### Fixed
+
+- Improve memory efficiency of using `SIRFShampoo` with `verbose_init=True`
+  ([PR](https://github.com/f-dangel/sirfshampoo/pull/37))
 
 ## [0.0.1] - 2024-06-24
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Improve memory efficiency of using `SIRFShampoo` with `verbose_init=True`
+  ([PR](https://github.com/f-dangel/sirfshampoo/pull/37))
+
 ### Deprecated
 
 ### Fixed

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ doc =
     mkdocs-material==9.1.17
     mkdocstrings[python]==0.22.0
     mkdocs-gallery==0.7.8
+    griffe==0.45.3
     torchvision # MNIST
     pytest # for catching exceptions
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ setup_requires =
   setuptools_scm
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
-    singd>=0.0.4
+    singd>=0.0.5
     torch
     numpy
 # The usage of test_requires is discouraged, see `Dependency Management` docs

--- a/sirfshampoo/optimizer.py
+++ b/sirfshampoo/optimizer.py
@@ -234,7 +234,7 @@ https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.load_state_dict.
             param_names = [self.param_to_names[p.data_ptr()] for p in group["params"]]
             other = {k: v for k, v in group.items() if k != "params"}
             precs = self.preconditioner[i]
-            shapes = [(str(s) for s in p.to_dense().shape) for p in precs]
+            shapes = [(str(s) for s in p.shape) for p in precs]
             structures = [p.__class__.__name__ for p in precs]
             prec_desc = [
                 f"{'x'.join(shape)} ({structure})"


### PR DESCRIPTION
When using `verbose=True` in the optimizer, it prints the pre-conditioner shapes.
At the moment, this will convert the pre-conditioner to a dense matrix, then read out its shape.
This can go out of memory for high-dimensional pre-conditioners.
Therefore, this PR switches to using the latest version of `singd`, which introduced an efficient implementation of `.shape`.